### PR TITLE
Fix docker containers issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM python:3.8.0
 COPY . /app
 WORKDIR /app
 
+RUN apt-get -q update && apt-get -qy install netcat
 RUN pip install -U -r requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,8 @@ services:
       - DEBUG=1
     entrypoint: ""
     command: >
-      sh -c "alembic upgrade head &&
-             cd $$(pwd)/nflrushing &&
-             uvicorn main:app --host 0.0.0.0 --reload --port 8000"
+      sh -c "./wait-for.sh db:5432 -- alembic upgrade head &&
+             uvicorn nflrushing.main:app --host 0.0.0.0 --reload --port 8000"
 
   db:
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 alembic==1.3.0
 Click==7.0
+dnspython==1.16.0
+email-validator==1.0.5
 fastapi==0.42.0
 FastAPI-SQLAlchemy==0.1.1
 h11==0.8.1
 httptools==0.0.13
+idna==2.8
 Mako==1.1.0
 MarkupSafe==1.1.1
 psycopg2==2.8.4

--- a/wait-for.sh
+++ b/wait-for.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
There was an issue that was caused by the `web` container trying to reach **postrgresql** from the `db` container before it is fully initialized. The issue was fixed by introducing a `wait-for.sh` script that would *wait* for the `db` container to get fully initialized and then start the `web` one.